### PR TITLE
(FEAT/12) Modificado locate on screen no btn download pdf para pyautogui.press com a lógica de tabs

### DIFF
--- a/generate_das/generate_das.py
+++ b/generate_das/generate_das.py
@@ -142,7 +142,7 @@ pyautogui.press('space')
 
 # CLICK GENERATE DAS
 pyautogui.press('pgdn')
-pyautogui.sleep(1)
+loading_screen('btn_generate_das')
 generate_das = pyautogui.locateCenterOnScreen('images/btn_generate_das.png', confidence=0.95)
 pyautogui.click(generate_das.x, generate_das.y)
 

--- a/generate_das/generate_das.py
+++ b/generate_das/generate_das.py
@@ -148,6 +148,6 @@ pyautogui.click(generate_das.x, generate_das.y)
 
 # BAIXAR PDF
 loading_screen('component_modal_success', "component_modal_warning")
-download_pdf = pyautogui.locateCenterOnScreen('images/btn_download_pdf.png')
-pyautogui.click(download_pdf.x, download_pdf.y)
+pyautogui.press('tab', presses=6)
+pyautogui.press('enter')
 close_tab()


### PR DESCRIPTION
Foi retirado:
```
download_pdf = pyautogui.locateCenterOnScreen ( 'images/btn_download_pdf.png' )
pyautogui.click ( download_pdf.x, download_pdf.y )
```

E adicionado:
```
pyautogui.press('tab', presses=6)
pyautogui.press('enter')
```