### PR TITLE
(Feat/16)Implementado a lógica de tabs em Click Emitir Guia

### DIFF
--- a/generate_das/generate_das.py
+++ b/generate_das/generate_das.py
@@ -74,8 +74,8 @@ pyautogui.typewrite(cnpj)
 
 # LOGIN
 continue_btn = pyautogui.locateCenterOnScreen('images/btn_continue.png')
-pyautogui.moveTo(continue_btn.x, continue_btn.y, duration=0.2)
-pyautogui.click(continue_btn.x, continue_btn.y)
+pyautogui.press('tab', presses=3)
+pyautogui.press('enter')
 
 # CLICK EMITIR GUIA
 loading_screen('home')

--- a/generate_das/generate_das.py
+++ b/generate_das/generate_das.py
@@ -73,14 +73,13 @@ loading_screen('login')
 pyautogui.typewrite(cnpj)
 
 # LOGIN
-continue_btn = pyautogui.locateCenterOnScreen('images/btn_continue.png')
 pyautogui.press('tab', presses=3)
 pyautogui.press('enter')
 
 # CLICK EMITIR GUIA
 loading_screen('home')
-link_emit_guia = pyautogui.locateCenterOnScreen('images/link_emit_guia.png', confidence=0.8)
-pyautogui.click(link_emit_guia.x, link_emit_guia.y)
+pyautogui.press('tab', presses=2)
+pyautogui.press('enter')
 
 # CLICK SELECT ANO
 loading_screen('screen_year')


### PR DESCRIPTION
- Foi verificado que não é mais necessário a seguinte linha de comando com a alteração anterior da feat/15, assim, foi removido:

`continue_btn = pyautogui.locateCenterOnScreen('images/btn_continue.png')`

- Alterado a lógica de tabs no Click Emitir Guia.
Antes:
`link_emit_guia = pyautogui.locateCenterOnScreen('images/link_emit_guia.png', confidence=0.8)
pyautogui.click(link_emit_guia.x, link_emit_guia.y)`

Depois:
`pyautogui.press('tab', presses=2)
pyautogui.press('enter')`


- Sugestão: remover as imagens das linhas de código retiradas e que não serão mais usadas